### PR TITLE
Remove unneccs step in pipeline

### DIFF
--- a/.github/workflows/publish-on-main.yml
+++ b/.github/workflows/publish-on-main.yml
@@ -105,6 +105,4 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "Publishing $(node -e 'console.log(require(\"./package.json\").version)')..."
-          npm publish --access public
+        run: npm publish --access public


### PR DESCRIPTION
When publishing, npm will show the package version anyway, so the block is redundant.